### PR TITLE
Improved palette fade (#7)

### DIFF
--- a/src/fade.c
+++ b/src/fade.c
@@ -1,10 +1,37 @@
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
 #include <outcurses.h>
 
+// A set of RGB color components
+typedef struct ccomps {
+	int r, g, b;
+} ccomps;
+
+// These arrays are too large to be safely placed on the stack.
+static int
+alloc_ccomps(int count, ccomps** orig, ccomps** cur){
+	*orig = malloc(count * sizeof(ccomps));
+	*cur = malloc(count * sizeof(ccomps));
+	if(*orig == NULL || *cur == NULL){
+		free(*orig);
+		free(*cur);
+		*orig = NULL;
+		*cur = NULL;
+		return -1;
+	}
+	return 0;
+}
+
 int fade(WINDOW* w, unsigned sec){
-	int origr[COLORS], origg[COLORS], origb[COLORS];
-	short r[COLORS], g[COLORS], b[COLORS];
+	ccomps* orig;
+	ccomps* cur;
+	int ret;
+
+	ret = -1;
+	if(alloc_ccomps(COLORS, &orig, &cur)){
+		goto done;
+	}
 	// ncurses palettes are in terms of 0..1000, so there's no point in
 	// trying to do more than 1000 iterations, ever. This is in usec.
 	const long unsigned quanta = sec * 1000000 / 15;
@@ -13,12 +40,12 @@ int fade(WINDOW* w, unsigned sec){
 	int p;
 
 	for(p = 0 ; p < COLORS ; ++p){
-		if(extended_color_content(p, origr + p, origg + p, origb + p) != OK){
-			return -1;
+		if(extended_color_content(p, &orig[p].r, &orig[p].g, &orig[p].b) != OK){
+			goto done;
 		}
-		r[p] = origr[p];
-		g[p] = origg[p];
-		b[p] = origb[p];
+		cur[p].r = orig[p].r;
+		cur[p].g = orig[p].g;
+		cur[p].b = orig[p].b;
 	}
 	gettimeofday(&stime, NULL);
 	cus = sus = stime.tv_sec * 1000000 + stime.tv_usec;
@@ -31,17 +58,17 @@ int fade(WINDOW* w, unsigned sec){
 			permille = 1000;
 		}
 		for(p = 0 ; p < COLORS ; ++p){
-			r[p] = (origr[p] * (1000 - permille)) / 1000;
-			g[p] = (origg[p] * (1000 - permille)) / 1000;
-			b[p] = (origb[p] * (1000 - permille)) / 1000;
-			if(init_extended_color(p, r[p], g[p], b[p]) != OK){
-				return -1;
+			cur[p].r = (orig[p].r * (1000 - permille)) / 1000;
+			cur[p].g = (orig[p].g * (1000 - permille)) / 1000;
+			cur[p].b = (orig[p].b * (1000 - permille)) / 1000;
+			if(init_extended_color(p, cur[p].r, cur[p].g, cur[p].b) != OK){
+				goto done;
 			}
 		}
 		usleep(quanta);
 		for(p = 0 ; p < pairs ; ++p){
 			if(init_extended_pair(p, p, -1) != OK){
-				return -1;
+				goto done;
 			}
 		}
 	    wrefresh(w);
@@ -49,10 +76,15 @@ int fade(WINDOW* w, unsigned sec){
 		cus = ctime.tv_sec * 1000000 + ctime.tv_usec;
 	}
 	for(p = 0 ; p < COLORS ; ++p){
-		if(init_extended_color(p, origr[p], origg[p], origb[p]) != OK){
-			return -1;
+		if(init_extended_color(p, orig[p].r, orig[p].g, orig[p].b) != OK){
+			goto done;
 		}
 	}
 	wrefresh(w);
-	return 0; // FIXME get real result, feeling free to abort early
+	ret = 0;
+
+done:
+	free(orig);
+	free(cur);
+	return ret;
 }

--- a/src/fade.c
+++ b/src/fade.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/time.h>
 #include <outcurses.h>
 
@@ -49,7 +48,10 @@ set_palette(int count, const ccomps* palette){
 	return 0;
 }
 
+#define NANOSECS_IN_SEC 1000000000ull
+
 int fade(WINDOW* w, unsigned sec){
+	uint64_t nanosecs;
 	ccomps* orig;
 	ccomps* cur;
 	int ret;
@@ -68,6 +70,7 @@ int fade(WINDOW* w, unsigned sec){
 			goto done;
 	}
 	memcpy(cur, orig, sizeof(*cur) * COLORS);
+	nanosecs = sec * NANOSECS_IN_SEC;
 	gettimeofday(&stime, NULL);
 	cus = sus = stime.tv_sec * 1000000 + stime.tv_usec;
 	while(cus < sus + sec * 1000000){
@@ -87,8 +90,8 @@ int fade(WINDOW* w, unsigned sec){
 				goto done;
 			}
 		}
-		usleep(quanta);
-		for(p = 0 ; p < pairs ; ++p){
+		// Pairs start at 1
+		for(p = 1 ; p < pairs ; ++p){
 			if(init_extended_pair(p, p, -1) != OK){
 				goto done;
 			}
@@ -100,7 +103,7 @@ int fade(WINDOW* w, unsigned sec){
 	if(set_palette(COLORS, orig)){
 		goto done;
 	}
-	wrefresh(w);
+	reset_color_pairs();
 	ret = 0;
 
 done:

--- a/tests/fade.cpp
+++ b/tests/fade.cpp
@@ -19,7 +19,7 @@ TEST(OutcursesFade, Fade) {
 	  wprintw(stdscr, "*");
 	}
   }
-  ASSERT_EQ(0, Outcurses::fade(stdscr, 5));
+  ASSERT_EQ(0, Outcurses::fade(stdscr, 2));
   // This should return OK, but fails in headless environments. Check
   // isendwin() afterwards as a proxy for this function, instead. FIXME
   ASSERT_EQ(0, Outcurses::stop_outcurses(true));

--- a/tests/fade.cpp
+++ b/tests/fade.cpp
@@ -19,7 +19,7 @@ TEST(OutcursesFade, Fade) {
 	  wprintw(stdscr, "*");
 	}
   }
-  ASSERT_EQ(0, Outcurses::fade(stdscr, 2));
+  ASSERT_EQ(0, Outcurses::fade(stdscr, 5));
   // This should return OK, but fails in headless environments. Check
   // isendwin() afterwards as a proxy for this function, instead. FIXME
   ASSERT_EQ(0, Outcurses::stop_outcurses(true));


### PR DESCRIPTION
* Adaptive clock_nanosleep() in fade() (#7) -- no longer use CPU on long fades
* Lift pairs init loop out of main loop
* Allocate color arrays on heap, not stack

This brings palette fading to the desired level of functionality, I think. w00t!
