### PR TITLE
Fix PowerOfTen tests of genprefix

### DIFF
--- a/include/outcurses.h
+++ b/include/outcurses.h
@@ -36,7 +36,7 @@ int fade(WINDOW* w, unsigned ms);
 // buf: buffer in which string will be generated
 // bsize: size of buffer. ought be at least PREFIXSTRLEN
 // omitdec: inhibit printing of all-0 decimal portions
-// mult: base of suffix system (1000 or 1024)
+// mult: base of suffix system (almost always 1000 or 1024)
 // uprefix: character to print following suffix ('i' for kibibytes basically).
 //   only printed if suffix is actually printed (input >= mult).
 //
@@ -56,12 +56,12 @@ genprefix(uintmax_t val, unsigned decimal, char *buf, size_t bsize,
 	dv = mult;
 	while((val / decimal) >= dv && consumed < strlen(prefixes)){
 		dv *= mult;
+		++consumed;
 		if(UINTMAX_MAX / dv < mult){ // watch for overflow
 			break;
 		}
-		++consumed;
 	}
-	if(dv != mult){
+	if(dv != mult){ // if consumed == 0, dv must equal mult
 		dv /= mult;
 		val /= decimal;
 		// Remainder is val % dv; we want a percentage as scaled integer

--- a/tests/prefix.cpp
+++ b/tests/prefix.cpp
@@ -25,7 +25,7 @@ TEST(OutcursesPrefix, EasyInts) {
 	// FIXME
 }
 
-const char suffixes[] = "\0KMGTPEY";
+const char suffixes[] = "\0KMGTPE";
 
 TEST(OutcursesPrefix, PowersOfTen) {
 	char buf[PREFIXSTRLEN + 1];
@@ -33,7 +33,8 @@ TEST(OutcursesPrefix, PowersOfTen) {
 	char str1[] = "1.00 ";
 	char str2[] = "10.00 ";
 	char str3[] = "100.00 ";
-	for(int i = 0 ; i < sizeof(suffixes) * 3 ; ++i){
+	int i = 0;
+	do{
 		genprefix(val, 1, buf, sizeof(buf), 0, 1000, '\0');
 		int sidx = i / 3;
 		switch(i % 3){
@@ -50,8 +51,13 @@ TEST(OutcursesPrefix, PowersOfTen) {
 			EXPECT_STREQ(str3, buf);
 			break;
 		}
+		if(UINTMAX_MAX / val < 10){
+			break;
+		}
 		val *= 10;
-	}
+	}while(++i < sizeof(suffixes) * 3);
+	// If we ran through all our suffixes, that's a problem
+	EXPECT_GT(sizeof(suffixes) * 3, i);
 }
 
 TEST(OutcursesPrefix, PowersOfTenNoDec) {
@@ -60,7 +66,8 @@ TEST(OutcursesPrefix, PowersOfTenNoDec) {
 	char str1[] = "1 ";
 	char str2[] = "10 ";
 	char str3[] = "100 ";
-	for(int i = 0 ; i < sizeof(suffixes) * 3 ; ++i){
+	int i = 0;
+	do{
 		genprefix(val, 1, buf, sizeof(buf), 1, 1000, '\0');
 		int sidx = i / 3;
 		switch(i % 3){
@@ -77,6 +84,11 @@ TEST(OutcursesPrefix, PowersOfTenNoDec) {
 			EXPECT_STREQ(str3, buf);
 			break;
 		}
+		if(UINTMAX_MAX / val < 10){
+			break;
+		}
 		val *= 10;
-	}
+	}while(++i < sizeof(suffixes) * 3);
+	// If we ran through all our suffixes, that's a problem
+	EXPECT_GT(sizeof(suffixes) * 3, i);
 }

--- a/tests/prefix.cpp
+++ b/tests/prefix.cpp
@@ -28,11 +28,11 @@ TEST(OutcursesPrefix, EasyInts) {
 const char suffixes[] = "\0KMGTPEY";
 
 TEST(OutcursesPrefix, PowersOfTen) {
-	char buf[PREFIXSTRLEN];
+	char buf[PREFIXSTRLEN + 1];
 	uintmax_t val = 1;
 	char str1[] = "1.00 ";
 	char str2[] = "10.00 ";
-	char str3[] = "100.0 ";
+	char str3[] = "100.00 ";
 	for(int i = 0 ; i < sizeof(suffixes) * 3 ; ++i){
 		genprefix(val, 1, buf, sizeof(buf), 0, 1000, '\0');
 		int sidx = i / 3;
@@ -46,7 +46,7 @@ TEST(OutcursesPrefix, PowersOfTen) {
 			EXPECT_STREQ(str2, buf);
 			break;
 			case 2:
-			str3[5] = suffixes[sidx];
+			str3[6] = suffixes[sidx];
 			EXPECT_STREQ(str3, buf);
 			break;
 		}
@@ -55,7 +55,7 @@ TEST(OutcursesPrefix, PowersOfTen) {
 }
 
 TEST(OutcursesPrefix, PowersOfTenNoDec) {
-	char buf[PREFIXSTRLEN];
+	char buf[PREFIXSTRLEN + 1];
 	uintmax_t val = 1;
 	char str1[] = "1 ";
 	char str2[] = "10 ";


### PR DESCRIPTION
Fix a number of errors in genprefix() flushed out via unit testing. These bugs have likely existed for close to a decade :/.