### PR TITLE
Panelreel event handler

### DIFF
--- a/include/outcurses.h
+++ b/include/outcurses.h
@@ -109,8 +109,11 @@ struct panelreel;
 // failure. w must be a valid WINDOW*, to which offsets are relative. Note that
 // there might not be enough room for the specified offsets, in which case the
 // panelreel will be clipped on the bottom and right. A minimum number of rows
-// and columns can be enforced via popts.
-struct panelreel* panelreel_create(WINDOW* w, const panelreel_options* popts);
+// and columns can be enforced via popts. efd, if non-negative, is an eventfd
+// that ought be written to whenever panelreel_touch() updates a tablet (this
+// is useful in the case of nonblocking input).
+struct panelreel* panelreel_create(WINDOW* w, const panelreel_options* popts,
+                                   int efd);
 
 // Tablet draw callback, provided a PANEL (from which a WINDOW may be derived),
 // the first column that may be used, the first row that may be used, the first

--- a/src/bin/panelreel.c
+++ b/src/bin/panelreel.c
@@ -130,6 +130,7 @@ handle_input(WINDOW* w, struct panelreel* pr, int efd, int y, int x){
   };
   int key = -1;
   int pret;
+  wrefresh(w);
   do{
     pret = poll(fds, sizeof(fds) / sizeof(*fds), -1);
     if(pret < 0){

--- a/src/bin/panelreel.c
+++ b/src/bin/panelreel.c
@@ -119,6 +119,12 @@ new_tabletctx(struct panelreel* pr, unsigned *id){
   return tctx;
 }
 
+static int
+handle_input(WINDOW* w, int y, int x){
+  int key = mvwgetch(w, y, x);
+  return key;
+}
+
 struct panelreel* panelreel_demo(WINDOW* w){
   int x = 4, y = 4;
   panelreel_options popts = {
@@ -138,7 +144,7 @@ struct panelreel* panelreel_demo(WINDOW* w){
     .boff = 0,
   };
   tabletctx* tctxs = NULL;
-  struct panelreel* pr = panelreel_create(w, &popts);
+  struct panelreel* pr = panelreel_create(w, &popts, -1);
   if(pr == NULL){
     fprintf(stderr, "Error creating panelreel\n");
     return NULL;
@@ -159,10 +165,9 @@ struct panelreel* panelreel_demo(WINDOW* w){
     wclrtoeol(w);
     pair = COLOR_BLUE;
     wattr_set(w, A_NORMAL, 0, &pair);
-    key = mvwgetch(w, 3, 2);
+    key = handle_input(w, 3, 2);
     clrtoeol();
     struct tabletctx* newtablet = NULL;
-    clrtoeol();
     switch(key){
       case 'a': newtablet = new_tabletctx(pr, &id); break;
       case 'b': newtablet = new_tabletctx(pr, &id); break;

--- a/src/bin/panelreel.c
+++ b/src/bin/panelreel.c
@@ -63,7 +63,7 @@ tabletdraw(PANEL* p, int begx, int begy, int maxx, int maxy, bool cliptop,
     err |= mvwprintw(w, begy, begx, "[#%u %dll %u/%u] ", tctx->id, tctx->lines, begy, maxy);
   }
 // fprintf(stderr, "  \\--> callback for %d, %d lines (%d/%d -> %d/%d) wrote: %d ret: %d\n", tctx->id,
-//    tctx->lines, begy, begx, maxy, maxx, y - begy, err);
+//     tctx->lines, begy, begx, maxy, maxx, y - begy, err);
   pthread_mutex_unlock(&tctx->lock);
   assert(OK == err);
   return y - begy;

--- a/src/lib/panelreel.c
+++ b/src/lib/panelreel.c
@@ -223,13 +223,12 @@ assert(direction >= 0); // FIXME don't yet support drawing up
     int trueby = getbegy(w);
     int truey, truex;
     getmaxyx(w, truey, truex);
-// fprintf(stderr, "TRUEY: %d BEGY: %d LENY: %d\n", truey, begy, leny);
     if(truey != leny){
+// fprintf(stderr, "RESIZE TRUEY: %d BEGY: %d LENY: %d\n", truey, begy, leny);
       if(wresize(w, leny, truex)){
         return -1;
       }
       atomic_store(&t->update_pending, true);
-      update_panels();
       getmaxyx(w, truey, truex);
     }
     if(begy != trueby){
@@ -281,7 +280,6 @@ assert(direction >= 0); // FIXME don't yet support drawing up
         wresize(w, ll + 2, lenx);
       }
     }
-    update_panels();
     draw_borders(w, pr->popts.tabletmask,
                  direction == 0 ? pr->popts.focusedattr : pr->popts.tabletattr,
                  direction == 0 ? pr->popts.focusedpair : pr->popts.tabletpair,

--- a/src/lib/panelreel.c
+++ b/src/lib/panelreel.c
@@ -225,10 +225,11 @@ assert(direction >= 0); // FIXME don't yet support drawing up
     int truey, truex;
     getmaxyx(w, truey, truex);
 // fprintf(stderr, "TRUEY: %d BEGY: %d LENY: %d\n", truey, begy, leny);
-    if(truey > leny){
+    if(truey != leny){
       if(wresize(w, leny, truex)){
         return -1;
       }
+      atomic_store(&t->update_pending, true);
       update_panels();
       getmaxyx(w, truey, truex);
     }
@@ -532,7 +533,7 @@ int panelreel_touch(panelreel* pr, tablet* t){
 
 // Move to some position relative to the current position
 static int
-move_reel_panel(PANEL* p, int deltax, int deltay){
+move_tablet(PANEL* p, int deltax, int deltay){
   WINDOW* w = panel_window(p);
   int oldx, oldy;
   getbegyx(w, oldy, oldx);
@@ -550,7 +551,7 @@ int panelreel_move(panelreel* preel, int x, int y){
   getbegyx(w, oldy, oldx);
   const int deltax = x - oldx;
   const int deltay = y - oldy;
-  if(move_reel_panel(preel->p, deltax, deltay)){
+  if(move_tablet(preel->p, deltax, deltay)){
     move_panel(preel->p, oldy, oldx);
     panelreel_redraw(preel);
     return -1;
@@ -561,14 +562,14 @@ int panelreel_move(panelreel* preel, int x, int y){
       if(t->p == NULL){
         break;
       }
-      move_reel_panel(t->p, deltax, deltay);
+      move_tablet(t->p, deltax, deltay);
     }while((t = t->prev) != preel->tablets);
     if(t != preel->tablets){ // don't repeat if we covered all tablets
       for(t = preel->tablets->next ; t != preel->tablets ; t = t->next){
         if(t->p == NULL){
           break;
         }
-        move_reel_panel(t->p, deltax, deltay);
+        move_tablet(t->p, deltax, deltay);
       }
     }
   }

--- a/src/lib/panelreel.c
+++ b/src/lib/panelreel.c
@@ -33,7 +33,6 @@ typedef struct panelreel {
   // These values could all be derived at any time, but keeping them computed
   // makes other things easier, or saves us time (at the cost of complexity).
   int tabletcount;         // could be derived, but we keep it o(1)
-  tablet* bottomtab;       // tablet currently at the bottom, can be NULL
 } panelreel;
 
 // Returns the starting coordinates (relative to the screen) of the specified

--- a/tests/panelreel.cpp
+++ b/tests/panelreel.cpp
@@ -13,7 +13,7 @@ TEST_F(PanelReelTest, InitLinear) {
   }
   panelreel_options p = { };
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -25,7 +25,7 @@ TEST_F(PanelReelTest, InitLinearInfinite) {
   panelreel_options p{};
   p.infinitescroll = true;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -38,7 +38,7 @@ TEST_F(PanelReelTest, InitCircular) {
   p.infinitescroll = true;
   p.circular = true;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   ASSERT_EQ(0, panelreel_destroy(pr));
   ASSERT_EQ(0, outcurses_stop(true));
@@ -53,7 +53,7 @@ TEST_F(PanelReelTest, FiniteCircleRejected) {
   p.infinitescroll = false;
   p.circular = true;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_EQ(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -67,7 +67,7 @@ TEST_F(PanelReelTest, MovementWithoutTablets) {
   panelreel_options p{};
   p.infinitescroll = false;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   EXPECT_EQ(0, panelreel_next(pr));
   EXPECT_EQ(0, panelreel_prev(pr));
@@ -92,7 +92,7 @@ TEST_F(PanelReelTest, OneTablet) {
   panelreel_options p{};
   p.infinitescroll = false;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   struct tablet* t = panelreel_add(pr, nullptr, nullptr, panelcb, nullptr);
   ASSERT_NE(nullptr, t);
@@ -107,7 +107,7 @@ TEST_F(PanelReelTest, DeleteActiveTablet) {
   panelreel_options p{};
   p.infinitescroll = false;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   struct tablet* t = panelreel_add(pr, nullptr, nullptr, panelcb, nullptr);
   ASSERT_NE(nullptr, t);
@@ -123,7 +123,7 @@ TEST_F(PanelReelTest, NoBorder) {
   p.bordermask = BORDERMASK_LEFT | BORDERMASK_RIGHT |
                   BORDERMASK_TOP | BORDERMASK_BOTTOM;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -135,7 +135,7 @@ TEST_F(PanelReelTest, BadBorderBitsRejected) {
   panelreel_options p{};
   p.bordermask = BORDERMASK_LEFT * 2;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_EQ(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -148,7 +148,7 @@ TEST_F(PanelReelTest, NoTabletBorder) {
   p.tabletmask = BORDERMASK_LEFT | BORDERMASK_RIGHT |
                   BORDERMASK_TOP | BORDERMASK_BOTTOM;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_NE(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -160,7 +160,7 @@ TEST_F(PanelReelTest, BadTabletBorderBitsRejected) {
   panelreel_options p{};
   p.tabletmask = BORDERMASK_LEFT * 2;
   ASSERT_NE(nullptr, outcurses_init(true));
-  struct panelreel* pr = panelreel_create(stdscr, &p);
+  struct panelreel* pr = panelreel_create(stdscr, &p, -1);
   ASSERT_EQ(nullptr, pr);
   ASSERT_EQ(0, outcurses_stop(true));
 }
@@ -201,7 +201,7 @@ TEST_F(PanelReelTest, InitWithinSubwin) {
   ASSERT_NE(nullptr, base);
   WINDOW* basew = panel_window(base);
   ASSERT_NE(nullptr, basew);
-  struct panelreel* pr = panelreel_create(basew, &p);
+  struct panelreel* pr = panelreel_create(basew, &p, -1);
   ASSERT_NE(nullptr, pr);
   EXPECT_EQ(0, panelreel_validate(basew, pr));
   ASSERT_EQ(0, panelreel_destroy(pr));
@@ -221,7 +221,7 @@ TEST_F(PanelReelTest, SubwinNoOffsetGeom) {
   ASSERT_NE(nullptr, base);
   WINDOW* basew = panel_window(base);
   ASSERT_NE(nullptr, basew);
-  struct panelreel* pr = panelreel_create(basew, &p);
+  struct panelreel* pr = panelreel_create(basew, &p, -1);
   ASSERT_NE(nullptr, pr);
   EXPECT_EQ(0, panelreel_validate(basew, pr));
   ASSERT_EQ(0, panelreel_destroy(pr));


### PR DESCRIPTION
* Accept an `eventfd` into panelreel, and `write()` to it on `panelreel_touch()` (#52)
* Get rid of residue on panel shrinks via removal of unnecessary `update_panels()` calls (#65)
