### PR TITLE
Handle denormalized (unfilled) panelreel rotations (#74)

### DIFF
--- a/include/outcurses.h
+++ b/include/outcurses.h
@@ -166,7 +166,7 @@ int panelreel_move(struct panelreel* pr, int x, int y);
 
 // Redraw the panelreel in its entirety, for instance after
 // clearing the screen due to external corruption, or a SIGWINCH.
-int panelreel_redraw(const struct panelreel* pr);
+int panelreel_redraw(struct panelreel* pr);
 
 // Return the focused tablet, if any tablets are present. This is not a copy;
 // be careful to use it only for the duration of a critical section.

--- a/src/bin/demo.h
+++ b/src/bin/demo.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-#define FADE_MILLISECONDS 750
+#define FADE_MILLISECONDS 500
 
 int widecolor_demo(WINDOW* w);
 int panelreel_demo(WINDOW* w);


### PR DESCRIPTION
* widecolor-demo: 500ms instead of 750ms per screen
* panelreel: rigorourize incomplete panelreel rotations, completing panelreel (#74)